### PR TITLE
comment-out ARMA_DONT_USE_CXX11

### DIFF
--- a/src/NetRep_types.h
+++ b/src/NetRep_types.h
@@ -2,4 +2,4 @@
 #define ARMA_USE_BLAS
 #define ARMA_NO_DEBUG
 #define ARMA_DONT_PRINT_ERRORS
-#define ARMA_DONT_USE_CXX11
+//#define ARMA_DONT_USE_CXX11

--- a/src/checkFinite.cpp
+++ b/src/checkFinite.cpp
@@ -2,7 +2,7 @@
 #define ARMA_USE_BLAS
 #define ARMA_NO_DEBUG
 #define ARMA_DONT_PRINT_ERRORS
-#define ARMA_DONT_USE_CXX11
+//#define ARMA_DONT_USE_CXX11
 
 #include <RcppArmadillo.h>
 

--- a/src/netStats.h
+++ b/src/netStats.h
@@ -5,7 +5,7 @@
 #define ARMA_USE_BLAS
 #define ARMA_NO_DEBUG
 #define ARMA_DONT_PRINT_ERRORS
-#define ARMA_DONT_USE_CXX11
+//#define ARMA_DONT_USE_CXX11
 
 #include <RcppArmadillo.h>
 

--- a/src/scale.h
+++ b/src/scale.h
@@ -5,7 +5,7 @@
 #define ARMA_USE_BLAS
 #define ARMA_NO_DEBUG
 #define ARMA_DONT_PRINT_ERRORS
-#define ARMA_DONT_USE_CXX11
+//#define ARMA_DONT_USE_CXX11
 
 #include <RcppArmadillo.h>
 

--- a/src/thread-utils.cpp
+++ b/src/thread-utils.cpp
@@ -2,7 +2,7 @@
 #define ARMA_USE_BLAS
 #define ARMA_NO_DEBUG
 #define ARMA_DONT_PRINT_ERRORS
-#define ARMA_DONT_USE_CXX11
+//#define ARMA_DONT_USE_CXX11
 
 #include <RcppArmadillo.h>
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -5,7 +5,7 @@
 #define ARMA_USE_BLAS
 #define ARMA_NO_DEBUG
 #define ARMA_DONT_PRINT_ERRORS
-#define ARMA_DONT_USE_CXX11
+o//#define ARMA_DONT_USE_CXX11
 #define BOOST_DISABLE_ASSERTS
 
 #include <RcppArmadillo.h>


### PR DESCRIPTION
Hi Scott,

Conrad has prepared a first 10.1-RC1 release of Armadillo 10.1 which I bundled into a pre-release RcppArmadillo_0.10.0.1.0.tar.gz that is available from its repo and the [Rcpp-drat](http://rcppcore.github.io/drat/).

Armadillo now insists on C++11 as minimum standard. Given that R 4.0.* does the same, this is not much of constraint.  Your package, just like less than a handful of others, set 'no C++11' explicitly which clashes.  All it takes, as I verified, is to not say that.  The PR here does that.

I hope you can apply the PR or a variant of it and update NetRep "soon" to allow RcppArmadillo to update to Armadillo 10.1. 

Let us know if we can help. 

Cheers,  Dirk

/cc @conradsnicta